### PR TITLE
Fix that default color set is being fetched on update screen

### DIFF
--- a/screens/ManageEmotion.js
+++ b/screens/ManageEmotion.js
@@ -44,18 +44,23 @@ export default function ManageEmotion() {
   useNavigation;
 
   useEffect(() => {
-    if (isEditing) {
-      // Fetch the existing emotion data using editedEmotionId
-      loadEmotionData(editedEmotionId);
-    } else {
-      // Initialize with default values for adding a new emotion
-      setSelectedEmotion("happy");
-      setColor(DEFAULT_CONFIG["happy"].color);
-    }
+    const initializeEmotionData = async () => {
+      if (isEditing) {
+        // Fetch the existing emotion data using `editedEmotionId`
+        await loadEmotionData(editedEmotionId);
+      } else {
+        // Initialize with default values for adding a new emotion
+        setSelectedEmotion("happy");
+        setColor(DEFAULT_CONFIG["happy"].color);
+      }
+    };
+  
+    initializeEmotionData();
   }, [isEditing]);
-
+  
   useEffect(() => {
-    if (selectedEmotion && DEFAULT_CONFIG[selectedEmotion]) {
+    if (!isEditing && selectedEmotion && DEFAULT_CONFIG[selectedEmotion]) {
+      // Only update the color if not editing an existing emotion
       setColor(DEFAULT_CONFIG[selectedEmotion].color);
     }
   }, [selectedEmotion]);
@@ -85,7 +90,7 @@ export default function ManageEmotion() {
     try {
       const emotion = await fetchEmotionById(emotionId);
       console.log("Loaded emotion:", emotion);
-
+  
       if (DEFAULT_CONFIG[emotion.emotion]) {
         // If the emotion is predefined, set it as the selected emotion
         setSelectedEmotion(emotion.emotion);
@@ -95,8 +100,8 @@ export default function ManageEmotion() {
         setCustomEmotion(emotion.emotion);
         setSelectedEmotion(null); // Clear selectedEmotion since it's custom
       }
-
-      // Parse the color string back to RGB
+  
+      // Parse the color string back to RGB and set it
       setColor(parseColorString(emotion.color));
     } catch (error) {
       console.error("Failed to load emotion data:", error);


### PR DESCRIPTION
Updated Behavior:

When editing:
	•	The selected emotion’s color is fetched from the database and shown.
	•	Dropdown selection defaults to the emotion name if it exists in DEFAULT_CONFIG.
	•	Custom colors and names are handled separately.

When adding:
	•	Defaults are fetched from DEFAULT_CONFIG based on the selected emotion in the dropdown.

![Screenshot 2024-12-02 at 9 24 47 PM](https://github.com/user-attachments/assets/06b74dc4-2177-4ebe-9740-f96468e319d6)
<img width="435" alt="Screenshot 2024-12-02 at 9 23 53 PM" src="https://github.com/user-attachments/assets/d26cf971-3c0d-4fbf-9f78-e4bd66dd596b">
<img width="454" alt="Screenshot 2024-12-02 at 9 24 28 PM" src="https://github.com/user-attachments/assets/27d673f1-e48b-4d9e-8974-6ce1169daf72">
tched from DEFAULT_CONFIG based on the selected emotion in the dropdown.
	
	